### PR TITLE
Add initial logging configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
     - conda create -n test python=$PYTHONVER
     - source activate test
     - conda update -q -y --all
-    - conda install -q -y -c conda-forge six numpy pandas pytables numba
+    - conda install -q -y -c conda-forge six numpy pandas pytables numba pyyaml
     - conda install -q -y -c conda-forge sphinx sphinx_rtd_theme ply sympy
     - conda install -q -y -c conda-forge pandoc pypandoc nbsphinx ipython seaborn
     - conda install -q -y -c conda-forge coveralls coverage pytest pytest-cov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include exa/static *
+recursive-include exa/conf *
 include requirements.txt
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ install:
   - cmd: conda create -y -n test python=%CONDA_PY%
   - cmd: activate test
   - cmd: conda update -q -y --all
-  - cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas
+  - cmd: conda install -q -y -c conda-forge numpy scipy seaborn networkx pandas pyyaml
   - cmd: conda install -q -y -c conda-forge pytest pytables six numba sympy
   - cmd: pip install -e .
 

--- a/exa/__init__.py
+++ b/exa/__init__.py
@@ -5,6 +5,18 @@
 Exa
 #########
 """
+import os
+import tempfile
+import logging.config
+import yaml
+
+with open(os.path.join(os.path.dirname(__file__),
+          'conf', 'logging.yml'), 'r') as f:
+    _log = yaml.safe_load(f.read())
+_log['handlers']['file']['filename'] = os.path.join(tempfile.gettempdir(),
+                                                    'exa.log')
+logging.config.dictConfig(_log)
+
 from ._version import __version__
 from .core import (DataFrame, Series, Field3D, Field, Editor, Container,
                    TypedMeta, SparseDataFrame)

--- a/exa/conf/logging.yml
+++ b/exa/conf/logging.yml
@@ -1,0 +1,25 @@
+version: 1
+disable_existing_loggers: True
+formatters:
+    verbose:
+        format: '[%(levelname)s %(asctime)s] %(name)s %(message)s'
+    simple:
+        format: '%(levelname)s %(message)s'
+handlers:
+    console:
+        level: DEBUG
+        class: logging.StreamHandler
+        formatter: 'verbose'
+    file:
+        level: INFO
+        class: logging.handlers.RotatingFileHandler
+        formatter: 'verbose'
+        filename: '/tmp/exa.log'
+        mode: 'a'
+        maxBytes: 10485760
+        backupCount: 5
+loggers:
+    exa:
+        handlers: ['console', 'file']
+        level: DEBUG
+        propagate: False

--- a/exa/core/container.py
+++ b/exa/core/container.py
@@ -13,6 +13,7 @@ See Also:
     For a description of data objects see :mod:`~exa.core.numerical`.
 """
 import os
+import logging
 import numpy as np
 import pandas as pd
 import networkx as nx
@@ -31,6 +32,12 @@ class Container(object):
     """
     _getter_prefix = 'compute'
     _cardinal = None    # Name of the cardinal data table
+
+    @property
+    def log(self):
+        name = '.'.join([self.__module__,
+                         self.__class__.__name__])
+        return logging.getLogger(name)
 
     def copy(self, name=None, description=None, meta=None):
         """
@@ -474,6 +481,7 @@ class Container(object):
         raise KeyError()
 
     def __init__(self, name=None, description=None, meta=None, **kwargs):
+        self.log.info(f'adding {len(kwargs)} attrs')
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.name = name

--- a/exa/core/container.py
+++ b/exa/core/container.py
@@ -481,7 +481,7 @@ class Container(object):
         raise KeyError()
 
     def __init__(self, name=None, description=None, meta=None, **kwargs):
-        self.log.info(f'adding {len(kwargs)} attrs')
+        self.log.info('adding {} attrs'.format(len(kwargs)))
         for key, value in kwargs.items():
             setattr(self, key, value)
         self.name = name

--- a/exa/core/editor.py
+++ b/exa/core/editor.py
@@ -393,7 +393,7 @@ class Editor(object):
         self.meta = meta
         self.nprint = 30
         self.cursor = 0
-        self.log.debug(f'contains {len(self._lines)} lines')
+        self.log.debug('contains {} lines'.format(len(self._lines)))
 
     def __delitem__(self, line):
         del self._lines[line]     # "line" is the line number minus one

--- a/exa/core/editor.py
+++ b/exa/core/editor.py
@@ -10,6 +10,7 @@ does not behave like a fully fledged text editor but does have some basic find,
 replace, insert, etc. functionality.
 """
 from __future__ import print_function
+import logging
 import io, os, re, sys, six
 import pandas as pd
 import warnings
@@ -54,6 +55,12 @@ class Editor(object):
     """
     _getter_prefix = 'parse'
     _fmt = '{0}: {1}\n'.format   # Format for printing lines (see __repr__)
+
+    @property
+    def log(self):
+        name = '.'.join([self.__module__,
+                         self.__class__.__name__])
+        return logging.getLogger(name)
 
     def write(self, path=None, *args, **kwargs):
         """
@@ -386,6 +393,7 @@ class Editor(object):
         self.meta = meta
         self.nprint = 30
         self.cursor = 0
+        self.log.debug(f'contains {len(self._lines)} lines')
 
     def __delitem__(self, line):
         del self._lines[line]     # "line" is the line number minus one

--- a/exa/core/numerical.py
+++ b/exa/core/numerical.py
@@ -12,6 +12,7 @@ conversion of data into "traits" used in visualization and enforce relationships
 between data objects in a given container. Any of the objects provided by this
 module may be extended.
 """
+import logging
 import warnings
 import numpy as np
 import pandas as pd
@@ -25,6 +26,13 @@ class Numerical(object):
     objects, providing default trait functionality and clean representations
     when present as part of containers.
     """
+    @property
+    def log(self):
+        name = '.'.join([self.__module__,
+                         self.__class__.__name__])
+        return logging.getLogger(name)
+
+
     def slice_naive(self, key):
         """
         Slice a data object based on its index, either by value (.loc) or
@@ -204,6 +212,7 @@ class DataFrame(BaseDataFrame, pd.DataFrame):
 
     def __init__(self, *args, **kwargs):
         super(DataFrame, self).__init__(*args, **kwargs)
+        self.log.debug(f'shape: {self.shape}')
         if self._cardinal is not None:
             self._categories[self._cardinal[0]] = self._cardinal[1]
             self._columns.append(self._cardinal[0])
@@ -309,6 +318,7 @@ class Field(DataFrame):
             raise TypeError("Wrong type for field_values with type {}".format(type(field_values)))
         for i in range(len(self.field_values)):
             self.field_values[i].name = i
+        self.log.info(f'contains {len(self.field_values)} fields')
 
 
 class Field3D(Field):

--- a/exa/core/numerical.py
+++ b/exa/core/numerical.py
@@ -212,7 +212,7 @@ class DataFrame(BaseDataFrame, pd.DataFrame):
 
     def __init__(self, *args, **kwargs):
         super(DataFrame, self).__init__(*args, **kwargs)
-        self.log.debug(f'shape: {self.shape}')
+        self.log.debug('shape: {}'.format(self.shape))
         if self._cardinal is not None:
             self._categories[self._cardinal[0]] = self._cardinal[1]
             self._columns.append(self._cardinal[0])
@@ -318,7 +318,7 @@ class Field(DataFrame):
             raise TypeError("Wrong type for field_values with type {}".format(type(field_values)))
         for i in range(len(self.field_values)):
             self.field_values[i].name = i
-        self.log.info(f'contains {len(self.field_values)} fields')
+        self.log.info('contains {} fields'.format(len(self.field_values)))
 
 
 class Field3D(Field):

--- a/meta.yaml
+++ b/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - ipython
     - matplotlib
     - seaborn
+    - pyyaml
 
 test:
   imports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ six
 ipython
 matplotlib
 seaborn
-
+pyyaml


### PR DESCRIPTION
This merge request is meant to address https://github.com/exa-analytics/exatomic/issues/139 . I add pyyaml as a dependency so we can store logging configuration in a yaml file rather than in source. This new dependency could also be useful in exatomic to unclutter source by offloading many configurable parameters into yaml configuration files (thinking GUI params). I did not opt for a base logging class to avoid import dependency issues or require a new module file. 

This setup will allow almost all downstream objects to get quick access to logging statements by use of `self.log.[info,debug,warning,error,critical]('my message')` that include the source file tree, making it easier to write terse logging messages without loss of context. The default configuration proposed provides 2 distinct handlers, a `console` StreamHandler that defaults to `DEBUG` and a `file` RotatingFileHandler that defaults to `INFO`. The default file handler will use `tempfile.gettempdir` to find a temp directory to store persistent logging information. In some contexts however, it may be inconvenient to receive all debugging messages to, e.g., an interactive notebook environment, so you can set:

```python
import logging
logging.getLogger('exa').setLevel(logging.INFO)
logging.getLogger('exatomic').setLevel(logging.INFO)
```

And of course, these settings can be changed in the logging.yml config file so that they are the default behavior for your runtime. I have only scratched the surface of where and when to place logging statements with the appropriate logging levels, but already I observe some interesting "features" of the library by logging during important class `__init__`s