### PR TITLE
Deprecates exa.static

### DIFF
--- a/exa/static.py
+++ b/exa/static.py
@@ -5,28 +5,14 @@ Static Data Directory
 #############################################
 Provide the location of the static data.
 """
-import os
+import exa
 
 
 def staticdir():
-    """Return the location of the static data directory."""
-    root = os.path.abspath(os.path.dirname(__file__))
-    return os.path.join(root, "static")
+    exa.cfg.log.warning("use of exa.static is deprecated. use exa.cfg")
+    return exa.cfg.staticdir
 
 
 def resource(name):
-    """
-    Return the full path of a named resource in the static directory.
-
-    If multiple files with the same name exist, **name** should contain
-    the first directory as well.
-
-    .. code-block:: python
-
-        resource("myfile")
-        resource("test01/test.txt")
-        resource("test02/test.txt")
-    """
-    for path, _, files in os.walk(staticdir()):
-        if name in files:
-            return os.path.abspath(os.path.join(path, name))
+    exa.cfg.log.warning("use of exa.static is deprecated. use exa.cfg")
+    return exa.cfg.resource(name)


### PR DESCRIPTION
Methods on `exa.cfg` reproduce the `exa.static` API. Log a warning for downstream to update.